### PR TITLE
Harder inputs

### DIFF
--- a/src/ctpt.hrl
+++ b/src/ctpt.hrl
@@ -1,6 +1,7 @@
 -ifndef(CTPT_HRL).
 -define(CTPT_HRL, true).
 
+%% -define(SOME_VALUE, 42).
 -define(SOME_VALUE, 16#5f3759df).
 
 -endif.

--- a/src/ctpt.hrl
+++ b/src/ctpt.hrl
@@ -1,0 +1,6 @@
+-ifndef(CTPT_HRL).
+-define(CTPT_HRL, true).
+
+-define(SOME_VALUE, 16#5f3759df).
+
+-endif.

--- a/src/ctpt_demo.erl
+++ b/src/ctpt_demo.erl
@@ -4,9 +4,26 @@
 
 -include("ctpt.hrl").
 
+-define(HERE, io:format(user, " line:~p ", [?LINE])).
+
 -spec f(integer()) -> boolean().
 f(N) when is_integer(N) ->
     case N of
-        _ when N =:= ?SOME_VALUE -> false;
-        _ -> true
+        _ when N =:= ?SOME_VALUE -> ?HERE, false;
+        _ when N < ?SOME_VALUE/2 ->
+            case N of
+                _ when N =:= ?SOME_VALUE div 2 -> ?HERE, false;
+                _ when N < ?SOME_VALUE/4 ->
+                    case N of
+                        _ when N =:= ?SOME_VALUE div 4 -> ?HERE, false;
+                        _ when N < ?SOME_VALUE/8 ->
+                            case N of
+                                _ when N > ?SOME_VALUE/8 -> ?HERE, false;
+                                _ -> ?HERE, true
+                            end;
+                        _ -> ?HERE, true
+                    end;
+                _ -> ?HERE, true
+            end;
+        _ -> ?HERE, true
     end.

--- a/src/ctpt_demo.erl
+++ b/src/ctpt_demo.erl
@@ -9,18 +9,12 @@
 -spec f(integer()) -> boolean().
 f(N) when is_integer(N) ->
     case N of
-        _ when N =:= ?SOME_VALUE -> ?HERE, false;
-        _ when N < ?SOME_VALUE/2 ->
+        0 -> ?HERE, true;
+        _ when N rem 3 =:= 0 ->
             case N of
-                _ when N =:= ?SOME_VALUE div 2 -> ?HERE, false;
-                _ when N < ?SOME_VALUE/4 ->
+                _ when N rem 5 =:= 0 ->
                     case N of
-                        _ when N =:= ?SOME_VALUE div 4 -> ?HERE, false;
-                        _ when N < ?SOME_VALUE/8 ->
-                            case N of
-                                _ when N > ?SOME_VALUE/8 -> ?HERE, false;
-                                _ -> ?HERE, true
-                            end;
+                        _ when N rem 7 =:= 0 -> ?HERE, false;
                         _ -> ?HERE, true
                     end;
                 _ -> ?HERE, true

--- a/src/ctpt_demo.erl
+++ b/src/ctpt_demo.erl
@@ -2,9 +2,11 @@
 
 -export([f/1]).
 
+-include("ctpt.hrl").
+
 -spec f(integer()) -> boolean().
 f(N) when is_integer(N) ->
     case N of
-        _ when N =:= 42 -> false;
+        _ when N =:= ?SOME_VALUE -> false;
         _ -> true
     end.

--- a/src/ctpt_demo2.erl
+++ b/src/ctpt_demo2.erl
@@ -1,0 +1,21 @@
+-module(ctpt_demo2).
+
+-export([f/1]).
+
+-define(HERE, io:format(user, " line:~p ", [?LINE])).
+
+-spec f(string()) -> boolean().
+f(L) when is_list(L) ->
+    Len = length(L),
+    case Len > 0 andalso lists:nth(1,L) of
+        "H" ->
+            case Len > 1 andalso lists:nth(2,L) of
+                "i" ->
+                    case Len > 2 andalso lists:nth(3,L) of
+                        "!" -> ?HERE, false;
+                        _ -> ?HERE, true
+                    end;
+                _ -> ?HERE, true
+            end;
+        _ -> ?HERE, true
+    end.

--- a/src/ctpt_demo2.erl
+++ b/src/ctpt_demo2.erl
@@ -6,13 +6,12 @@
 
 -spec f(string()) -> boolean().
 f(L) when is_list(L) ->
-    Len = length(L),
-    case Len > 0 andalso lists:nth(1,L) of
-        "H" ->
-            case Len > 1 andalso lists:nth(2,L) of
-                "i" ->
-                    case Len > 2 andalso lists:nth(3,L) of
-                        "!" -> ?HERE, false;
+    case L of
+        "H"++_ ->
+            case L of
+                "Hi"++_ ->
+                    case L of
+                        "Hi!"++_ -> ?HERE, false;
                         _ -> ?HERE, true
                     end;
                 _ -> ?HERE, true

--- a/test/prop_02_informed.erl
+++ b/test/prop_02_informed.erl
@@ -2,11 +2,12 @@
 -module(prop_02_informed).
 
 -include_lib("proper/include/proper.hrl").
+-include("ctpt.hrl").
 
 %% An informed tester will try/guess some expected edge cases.
 
 expected_edge_cases() ->
-    oneof([-43,-42, -21, -3,-2-1, 0, 1,2,3, 21, 42,43]).
+    oneof([-43,-42, -21, -3,-2-1, 0, 1,2,3, 21, 43, ?SOME_VALUE]).
 
 prop_02() ->
     ?FORALL(N, expected_edge_cases(), ctpt_demo:f(N)).

--- a/test/prop_03_coverage_targeted.erl
+++ b/test/prop_03_coverage_targeted.erl
@@ -10,8 +10,10 @@ prop_03() ->
                     ,begin
                          ok = cover_begin(),
                          Result = ctpt_demo:f(N),
-                         {ok,Coverage} = cover_end(),
-                         ?MAXIMIZE(Coverage),
+                         {ok,_Percentage,_Covered} = cover_end(),
+                         io:format(user, "lines:~p %:~p", [_Covered,_Percentage]),
+                         ?MAXIMIZE(_Covered),
+                         %% ?MAXIMIZE(_Percentage),
                          Result
                      end
                     ).
@@ -27,11 +29,11 @@ cover_end() ->
     {result,Ok,_Fail=[]} = cover:analyse(coverage, line),
     ok = cover:stop(),
     {Covs,NotCovs} = lists:unzip([{Cov,NotCov} || {_ModLine, {Cov,NotCov}} <- Ok]),
+    Covered = lists:sum(Covs),
     Coverage =
         case lists:sum(NotCovs) of
             0 -> 100.0;
             NotCovered ->
-                Covered = lists:sum(Covs),
-                trunc(100 * (Covered / (Covered + NotCovered)))
+                trunc(100.0 * (Covered / (Covered + NotCovered)))
         end,
-    {ok, Coverage}.
+    {ok, Coverage, Covered}.

--- a/test/prop_03_coverage_targeted.erl
+++ b/test/prop_03_coverage_targeted.erl
@@ -13,8 +13,12 @@ prop_03() ->
                          {ok,_Percentage,_Covered,_NotCovered} = cover_end(),
 
                          io:format(user, "~p/~p ~s%\n", [_Covered,_Covered+_NotCovered,float_to_list(_Percentage,[{decimals,2},compact])]),
-                         ?MAXIMIZE(_Covered),
                          %% ?MAXIMIZE(_Percentage),
+                         %% ?MAXIMIZE(_Covered),
+                         %% Note: using number of lines covered instead of coverage% is consistently better in empirical tests
+                         %%   Maybe the search strategy sees more reward in an incr unbounded than whatever progress can be made within 0..1
+                         %% Turns out trying to reward more doesn't work (here): 2* or 3* does not ever find 105*_!
+                         ?MAXIMIZE(1 * _Covered),
                          Result
                      end
                     ).

--- a/test/prop_03_coverage_targeted.erl
+++ b/test/prop_03_coverage_targeted.erl
@@ -10,8 +10,9 @@ prop_03() ->
                     ,begin
                          ok = cover_begin(),
                          Result = ctpt_demo:f(N),
-                         {ok,_Percentage,_Covered} = cover_end(),
-                         io:format(user, "lines:~p %:~p", [_Covered,_Percentage]),
+                         {ok,_Percentage,_Covered,_NotCovered} = cover_end(),
+
+                         io:format(user, "~p/~p ~s%\n", [_Covered,_Covered+_NotCovered,float_to_list(_Percentage,[{decimals,2},compact])]),
                          ?MAXIMIZE(_Covered),
                          %% ?MAXIMIZE(_Percentage),
                          Result
@@ -29,11 +30,9 @@ cover_end() ->
     {result,Ok,_Fail=[]} = cover:analyse(coverage, line),
     ok = cover:stop(),
     {Covs,NotCovs} = lists:unzip([{Cov,NotCov} || {_ModLine, {Cov,NotCov}} <- Ok]),
-    Covered = lists:sum(Covs),
-    Coverage =
-        case lists:sum(NotCovs) of
-            0 -> 100.0;
-            NotCovered ->
-                trunc(100.0 * (Covered / (Covered + NotCovered)))
-        end,
-    {ok, Coverage, Covered}.
+    {Covered,NotCovered} = {lists:sum(Covs), lists:sum(NotCovs)},
+    Coverage = 100.0 * case NotCovered of
+                           0 -> 1;
+                           NotCovered -> Covered / (Covered + NotCovered)
+                       end,
+    {ok, Coverage, Covered, NotCovered}.

--- a/test/prop_04.erl
+++ b/test/prop_04.erl
@@ -1,0 +1,57 @@
+%% -*- coding: utf-8 -*-
+-module(prop_04).
+
+-include_lib("proper/include/proper.hrl").
+
+prop_04() ->
+    ?FORALL_TARGETED(L, string()
+                    ,begin
+                         ok = cover_begin(),
+                         Result = ctpt_demo2:f(L),
+                         {ok,_Percentage,_Covered,_NotCovered} = cover_end(),
+
+                         io:format(user, "~p/~p ~s%\n", [_Covered,_Covered+_NotCovered,float_to_list(_Percentage,[{decimals,2},compact])]),
+                         %% ?MAXIMIZE(_Percentage),
+                         %% ?MAXIMIZE(_Covered),
+                         %% Note: using number of lines covered instead of coverage% is consistently better in empirical tests
+                         %%   Maybe the search strategy sees more reward in an incr unbounded than whatever progress can be made within 0..1
+                         %% Turns out trying to reward more doesn't work (here): 2* or 3* does not ever find 105*_!
+                         ?MAXIMIZE(1 * _Covered),
+                         Result
+                     end
+                    ).
+
+cover_begin() ->
+    %% cover:compile_beam_directory("ebin")
+    {ok,_Pid} = cover:start(),
+    {ok,_Mod} = cover:compile("src/ctpt_demo2.erl"),
+    [_|_] = cover:modules(),
+    ok.
+
+cover_end() ->
+    {result,Ok,_Fail=[]} = cover:analyse(coverage, line),
+    ok = cover:stop(),
+    {Covs,NotCovs} = lists:unzip([{Cov,NotCov} || {_ModLine, {Cov,NotCov}} <- Ok]),
+    {Covered,NotCovered} = {lists:sum(Covs), lists:sum(NotCovs)},
+    Coverage = 100.0 * case NotCovered of
+                           0 -> 1;
+                           NotCovered -> Covered / (Covered + NotCovered)
+                       end,
+    {ok, Coverage, Covered, NotCovered}.
+
+
+%%% LibFuzzer finds this though
+%% #![no_main]
+%% #[macro_use] extern crate libfuzzer_sys;
+%% // cargo fuzz run fuzz_target_1
+%% fuzz_target!(|data: &[u8]| {
+%%     if let Ok(s) = std::str::from_utf8(data) {
+%%         if s.len() > 0 && s.get(0..1) == Some("H") {
+%%             if s.len() > 1 && s.get(1..2) == Some("i") {
+%%                 if s.len() > 2 && s.get(2..3) == Some("!") {
+%%                     panic!();
+%%                 }
+%%             }
+%%         }
+%%     }
+%% });


### PR DESCRIPTION
* Inputs larger than `integer 42` or even `string Hi!` are hard for PropEr to generate
* Using number of lines covered instead of coverage% is consistently better in empirical tests

Maybe libFuzzer's search strategy can be ported to PropEr?